### PR TITLE
Implement admin backoffice API config

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,13 +1,10 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
-if (!supabaseUrl || !supabaseKey) {
-  throw new Error('Missing Supabase environment variables. Please set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY in your .env file.');
-}
-
-export const supabase = createClient(supabaseUrl, supabaseKey);
+export const supabase: SupabaseClient | null =
+  supabaseUrl && supabaseKey ? createClient(supabaseUrl, supabaseKey) : null;
 
 export type Database = {
   public: {
@@ -99,6 +96,35 @@ export type Database = {
           full_name?: string;
           credits?: number;
           is_admin?: boolean;
+          updated_at?: string;
+        };
+      };
+      api_config: {
+        Row: {
+          id: string;
+          openai_key: string;
+          stability_key: string;
+          default_credits: number;
+          max_file_size: number;
+          allowed_formats: string[];
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          openai_key: string;
+          stability_key: string;
+          default_credits: number;
+          max_file_size: number;
+          allowed_formats: string[];
+          updated_at?: string;
+        };
+        Update: {
+          id?: string;
+          openai_key?: string;
+          stability_key?: string;
+          default_credits?: number;
+          max_file_size?: number;
+          allowed_formats?: string[];
           updated_at?: string;
         };
       };


### PR DESCRIPTION
## Summary
- add Supabase client fallback
- define `api_config` table in Supabase types
- load and persist API key settings from the new table

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6871570cbdcc8332a3ba045552ec31d2