### PR TITLE
Add simple i18n support

### DIFF
--- a/src/components/LanguageProvider.tsx
+++ b/src/components/LanguageProvider.tsx
@@ -1,0 +1,39 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+import { translations, Language } from '../i18n';
+
+interface LanguageContextProps {
+  lang: Language;
+  setLang: (lang: Language) => void;
+  t: (section: keyof typeof translations['en'], key: string) => string;
+}
+
+const LanguageContext = createContext<LanguageContextProps | undefined>(undefined);
+
+export const useLanguage = () => {
+  const ctx = useContext(LanguageContext);
+  if (!ctx) throw new Error('useLanguage must be used within LanguageProvider');
+  return ctx;
+};
+
+export const LanguageProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [lang, setLangState] = useState<Language>(() => {
+    const stored = localStorage.getItem('lang') as Language | null;
+    return stored || 'es';
+  });
+
+  const setLang = (newLang: Language) => {
+    localStorage.setItem('lang', newLang);
+    setLangState(newLang);
+  };
+
+  const t = (section: keyof typeof translations['en'], key: string) => {
+    // @ts-ignore
+    return translations[lang][section]?.[key] || translations['es'][section]?.[key] || key;
+  };
+
+  return (
+    <LanguageContext.Provider value={{ lang, setLang, t }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+};

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -3,19 +3,21 @@ import { Outlet, Link, useLocation } from 'react-router-dom';
 import { Sparkles, User, LogOut, Settings, Home, Upload } from 'lucide-react';
 import { useAuthContext } from './AuthProvider';
 import { motion } from 'framer-motion';
+import { useLanguage } from './LanguageProvider';
 
 const Layout: React.FC = () => {
   const { user, profile, signOut, isAuthenticated, isAdmin } = useAuthContext();
   const location = useLocation();
+  const { lang, setLang, t } = useLanguage();
 
   const navigation = [
-    { name: 'Inicio', href: '/', icon: Home },
-    { name: 'Generar', href: '/generate', icon: Upload },
-    { name: 'Mis Imágenes', href: '/gallery', icon: User },
+    { name: t('nav', 'home'), href: '/', icon: Home },
+    { name: t('nav', 'generate'), href: '/generate', icon: Upload },
+    { name: t('nav', 'gallery'), href: '/gallery', icon: User },
   ];
 
   const adminNavigation = [
-    { name: 'Admin', href: '/admin', icon: Settings },
+    { name: t('nav', 'admin'), href: '/admin', icon: Settings },
   ];
 
   const isActive = (path: string) => location.pathname === path;
@@ -41,6 +43,12 @@ const Layout: React.FC = () => {
             </Link>
 
             <div className="flex items-center space-x-4">
+              <button
+                onClick={() => setLang(lang === 'es' ? 'en' : 'es')}
+                className="px-3 py-2 text-gray-300 hover:text-white"
+              >
+                {lang === 'es' ? 'EN' : 'ES'}
+              </button>
               {isAuthenticated && (
                 <>
                   <div className="hidden md:flex items-center space-x-4">
@@ -82,14 +90,14 @@ const Layout: React.FC = () => {
 
                   <div className="flex items-center space-x-4">
                     <div className="text-sm text-gray-300">
-                      <span className="font-medium">{profile?.credits || 0}</span> créditos
+                      <span className="font-medium">{profile?.credits || 0}</span> {t('nav', 'credits')}
                     </div>
                     <button
                       onClick={handleSignOut}
                       className="flex items-center space-x-2 px-3 py-2 rounded-lg bg-red-600 hover:bg-red-700 text-white transition-all duration-200"
                     >
                       <LogOut className="h-4 w-4" />
-                      <span>Salir</span>
+                      <span>{t('nav', 'logout')}</span>
                     </button>
                   </div>
                 </>
@@ -101,13 +109,13 @@ const Layout: React.FC = () => {
                     to="/login"
                     className="px-4 py-2 text-gray-300 hover:text-white transition-colors"
                   >
-                    Iniciar Sesión
+                    {t('nav', 'login')}
                   </Link>
                   <Link
                     to="/register"
                     className="px-4 py-2 bg-purple-600 hover:bg-purple-700 text-white rounded-lg transition-all duration-200"
                   >
-                    Registrarse
+                    {t('nav', 'register')}
                   </Link>
                 </div>
               )}
@@ -123,7 +131,7 @@ const Layout: React.FC = () => {
       <footer className="bg-black/20 backdrop-blur-md border-t border-purple-500/20 py-8">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center text-gray-400">
-            <p>&copy; 2024 ViralGenAI. Convierte tu imagen en una tendencia.</p>
+            <p>&copy; 2024 ViralGenAI. {t('footer', 'text')}</p>
           </div>
         </div>
       </footer>

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Navigate } from 'react-router-dom';
 import { useAuthContext } from './AuthProvider';
+import { useLanguage } from './LanguageProvider';
 
 interface ProtectedRouteProps {
   children: React.ReactNode;
@@ -9,11 +10,12 @@ interface ProtectedRouteProps {
 
 const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children, requireAdmin = false }) => {
   const { isAuthenticated, isAdmin, loading } = useAuthContext();
+  const { t } = useLanguage();
 
   if (loading) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900 flex items-center justify-center">
-        <div className="text-white text-xl">Cargando...</div>
+        <div className="text-white text-xl">{t('common', 'loading')}</div>
       </div>
     );
   }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -2,6 +2,9 @@ export type Language = 'es' | 'en';
 
 export const translations = {
   es: {
+    common: {
+      loading: 'Cargando...'
+    },
     nav: {
       home: 'Inicio',
       generate: 'Generar',
@@ -33,7 +36,9 @@ export const translations = {
       forgot: '¿Olvidaste tu contraseña?',
       recover: 'Recuperar contraseña',
       submit: 'Iniciar sesión',
-      submitting: 'Iniciando sesión...'
+      submitting: 'Iniciando sesión...',
+      success: '¡Bienvenido de vuelta!',
+      error: 'Error al iniciar sesión'
     },
     register: {
       title: 'Crea tu cuenta',
@@ -44,7 +49,13 @@ export const translations = {
       password: 'Contraseña',
       placeholder_password: 'Mínimo 6 caracteres',
       submit: 'Crear cuenta',
-      submitting: 'Creando cuenta...'
+      submitting: 'Creando cuenta...',
+      success: '¡Cuenta creada exitosamente! Ya puedes generar imágenes.',
+      error: 'Error al crear la cuenta',
+      terms_prefix: 'Al registrarte, aceptas nuestros',
+      terms: 'términos de servicio',
+      privacy: 'política de privacidad',
+      free_credits: '🎉 ¡Obtén 3 créditos gratis para empezar a generar imágenes virales!'
     },
     gallery: {
       loading: 'Cargando tu galería...',
@@ -55,9 +66,40 @@ export const translations = {
       generate_first: 'Generar mi primera imagen',
       download: 'Descargar',
       delete_confirm: '¿Estás seguro de que quieres eliminar esta imagen?'
+    },
+    generate: {
+      title: 'Generar Imagen Viral',
+      subtitle: 'Sigue estos pasos para crear tu imagen viral',
+      step_template: '1. Plantilla',
+      step_upload: '2. Subir Imagen',
+      step_generate: '3. Generar',
+      step_result: '4. Resultado',
+      select_template: 'Selecciona una plantilla',
+      upload_image: 'Sube tu imagen',
+      change_template: 'Cambiar plantilla',
+      selected_template: 'Plantilla seleccionada',
+      drag_here: 'Suelta la imagen aquí',
+      drag_prompt: 'Arrastra una imagen o haz clic para seleccionar',
+      formats: 'Formatos soportados: JPG, PNG, WEBP',
+      image_uploaded: 'Imagen subida',
+      no_credits: 'Sin créditos suficientes',
+      generate_button: 'Generar Imagen Viral (1 crédito)',
+      generating: 'Generando tu imagen viral...',
+      generating_desc: 'Estamos aplicando la magia de la IA. Esto tomará unos segundos.',
+      result_title: '¡Tu imagen viral está lista!',
+      result_desc: 'Desliza para ver la comparación antes/después',
+      download: 'Descargar Imagen',
+      generate_another: 'Generar Otra',
+      error_loading_templates: 'Error al cargar las plantillas',
+      insufficient_credits: 'No tienes suficientes créditos para generar una imagen',
+      success: '¡Imagen generada exitosamente!',
+      error_generating: 'Error al generar la imagen'
     }
   },
   en: {
+    common: {
+      loading: 'Loading...'
+    },
     nav: {
       home: 'Home',
       generate: 'Generate',
@@ -89,7 +131,9 @@ export const translations = {
       forgot: 'Forgot your password?',
       recover: 'Recover password',
       submit: 'Log In',
-      submitting: 'Logging in...'
+      submitting: 'Logging in...',
+      success: 'Welcome back!',
+      error: 'Login failed'
     },
     register: {
       title: 'Create your account',
@@ -100,7 +144,13 @@ export const translations = {
       password: 'Password',
       placeholder_password: 'Minimum 6 characters',
       submit: 'Create Account',
-      submitting: 'Creating account...'
+      submitting: 'Creating account...',
+      success: 'Account created successfully! You can now generate images.',
+      error: 'Failed to create account',
+      terms_prefix: 'By signing up, you agree to our',
+      terms: 'terms of service',
+      privacy: 'privacy policy',
+      free_credits: '🎉 Get 3 free credits to start generating viral images!'
     },
     gallery: {
       loading: 'Loading your gallery...',
@@ -111,6 +161,34 @@ export const translations = {
       generate_first: 'Generate my first image',
       download: 'Download',
       delete_confirm: 'Are you sure you want to delete this image?'
+    },
+    generate: {
+      title: 'Generate Viral Image',
+      subtitle: 'Follow these steps to create your viral image',
+      step_template: '1. Template',
+      step_upload: '2. Upload Image',
+      step_generate: '3. Generate',
+      step_result: '4. Result',
+      select_template: 'Select a template',
+      upload_image: 'Upload your image',
+      change_template: 'Change template',
+      selected_template: 'Selected template',
+      drag_here: 'Drop the image here',
+      drag_prompt: 'Drag an image or click to select',
+      formats: 'Supported formats: JPG, PNG, WEBP',
+      image_uploaded: 'Image uploaded',
+      no_credits: 'Insufficient credits',
+      generate_button: 'Generate Viral Image (1 credit)',
+      generating: 'Generating your viral image...',
+      generating_desc: 'Applying AI magic. This will take a few seconds.',
+      result_title: 'Your viral image is ready!',
+      result_desc: 'Drag to compare before/after',
+      download: 'Download Image',
+      generate_another: 'Generate Another',
+      error_loading_templates: 'Error loading templates',
+      insufficient_credits: 'You do not have enough credits to generate an image',
+      success: 'Image generated successfully!',
+      error_generating: 'Error generating image'
     }
   }
 } as const;

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,118 @@
+export type Language = 'es' | 'en';
+
+export const translations = {
+  es: {
+    nav: {
+      home: 'Inicio',
+      generate: 'Generar',
+      gallery: 'Mis Imágenes',
+      admin: 'Admin',
+      credits: 'créditos',
+      logout: 'Salir',
+      login: 'Iniciar Sesión',
+      register: 'Registrarse'
+    },
+    footer: { text: 'Convierte tu imagen en una tendencia.' },
+    home: {
+      tagline1: 'Convierte tu imagen',
+      tagline2: 'en una tendencia',
+      hero_desc:
+        'Transforma tus fotos en imágenes virales usando IA generativa. Sin necesidad de saber ingeniería de prompts, solo sube tu imagen y elige una plantilla.',
+      generate_now: 'Generar Ahora',
+      start_free: 'Comenzar Gratis',
+      view_templates: 'Ver Plantillas',
+      why_choose: '¿Por qué elegir ViralGenAI?',
+      best_exp: 'Creamos la mejor experiencia para generar contenido viral'
+    },
+    login: {
+      title: 'Inicia sesión en tu cuenta',
+      no_account: '¿No tienes una cuenta?',
+      register_here: 'Regístrate aquí',
+      email: 'Correo electrónico',
+      password: 'Contraseña',
+      forgot: '¿Olvidaste tu contraseña?',
+      recover: 'Recuperar contraseña',
+      submit: 'Iniciar sesión',
+      submitting: 'Iniciando sesión...'
+    },
+    register: {
+      title: 'Crea tu cuenta',
+      have_account: '¿Ya tienes una cuenta?',
+      login_here: 'Inicia sesión aquí',
+      full_name: 'Nombre completo',
+      email: 'Correo electrónico',
+      password: 'Contraseña',
+      placeholder_password: 'Mínimo 6 caracteres',
+      submit: 'Crear cuenta',
+      submitting: 'Creando cuenta...'
+    },
+    gallery: {
+      loading: 'Cargando tu galería...',
+      my_gallery: 'Mi Galería de Imágenes Virales',
+      all_creations: 'Todas tus creaciones generadas con IA',
+      empty_title: 'Tu galería está vacía',
+      empty_desc: 'Aún no has generado ninguna imagen viral. ¡Empieza ahora!',
+      generate_first: 'Generar mi primera imagen',
+      download: 'Descargar',
+      delete_confirm: '¿Estás seguro de que quieres eliminar esta imagen?'
+    }
+  },
+  en: {
+    nav: {
+      home: 'Home',
+      generate: 'Generate',
+      gallery: 'My Images',
+      admin: 'Admin',
+      credits: 'credits',
+      logout: 'Logout',
+      login: 'Login',
+      register: 'Sign Up'
+    },
+    footer: { text: 'Turn your image into a trend.' },
+    home: {
+      tagline1: 'Turn your image',
+      tagline2: 'into a trend',
+      hero_desc:
+        'Transform your photos into viral images using generative AI. No prompt engineering needed, just upload your image and choose a template.',
+      generate_now: 'Generate Now',
+      start_free: 'Start Free',
+      view_templates: 'View Templates',
+      why_choose: 'Why choose ViralGenAI?',
+      best_exp: 'We create the best experience for generating viral content'
+    },
+    login: {
+      title: 'Sign in to your account',
+      no_account: "Don't have an account?",
+      register_here: 'Sign up here',
+      email: 'Email',
+      password: 'Password',
+      forgot: 'Forgot your password?',
+      recover: 'Recover password',
+      submit: 'Log In',
+      submitting: 'Logging in...'
+    },
+    register: {
+      title: 'Create your account',
+      have_account: 'Already have an account?',
+      login_here: 'Sign in here',
+      full_name: 'Full name',
+      email: 'Email',
+      password: 'Password',
+      placeholder_password: 'Minimum 6 characters',
+      submit: 'Create Account',
+      submitting: 'Creating account...'
+    },
+    gallery: {
+      loading: 'Loading your gallery...',
+      my_gallery: 'My Viral Image Gallery',
+      all_creations: 'All your creations generated with AI',
+      empty_title: 'Your gallery is empty',
+      empty_desc: "You haven't generated any viral images yet. Start now!",
+      generate_first: 'Generate my first image',
+      download: 'Download',
+      delete_confirm: 'Are you sure you want to delete this image?'
+    }
+  }
+} as const;
+
+export type TranslationKeys = keyof typeof translations['en'];

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
+import { LanguageProvider } from './components/LanguageProvider';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <LanguageProvider>
+      <App />
+    </LanguageProvider>
   </StrictMode>
 );

--- a/src/pages/Gallery.tsx
+++ b/src/pages/Gallery.tsx
@@ -5,6 +5,7 @@ import ReactCompareImage from 'react-compare-image';
 import { supabase } from '../lib/supabase';
 import { useAuthContext } from '../components/AuthProvider';
 import toast from 'react-hot-toast';
+import { useLanguage } from '../components/LanguageProvider';
 
 interface GeneratedImage {
   id: string;
@@ -22,6 +23,7 @@ const Gallery: React.FC = () => {
   const [images, setImages] = useState<GeneratedImage[]>([]);
   const [loading, setLoading] = useState(true);
   const { user } = useAuthContext();
+  const { t } = useLanguage();
 
   useEffect(() => {
     if (user) {
@@ -63,7 +65,7 @@ const Gallery: React.FC = () => {
   };
 
   const handleDelete = async (imageId: string) => {
-    if (!window.confirm('¿Estás seguro de que quieres eliminar esta imagen?')) {
+    if (!window.confirm(t('gallery', 'delete_confirm'))) {
       return;
     }
 
@@ -88,7 +90,7 @@ const Gallery: React.FC = () => {
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center">
           <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-purple-400 mx-auto mb-4"></div>
-          <p className="text-white text-xl">Cargando tu galería...</p>
+          <p className="text-white text-xl">{t('gallery', 'loading')}</p>
         </div>
       </div>
     );
@@ -104,10 +106,10 @@ const Gallery: React.FC = () => {
           className="text-center mb-12"
         >
           <h1 className="text-4xl font-bold text-white mb-4">
-            Mi Galería de Imágenes Virales
+            {t('gallery', 'my_gallery')}
           </h1>
           <p className="text-xl text-gray-300">
-            Todas tus creaciones generadas con IA
+            {t('gallery', 'all_creations')}
           </p>
         </motion.div>
 
@@ -121,16 +123,16 @@ const Gallery: React.FC = () => {
             <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-12 border border-white/20 max-w-md mx-auto">
               <Sparkles className="h-16 w-16 text-purple-400 mx-auto mb-6" />
               <h2 className="text-2xl font-bold text-white mb-4">
-                Tu galería está vacía
+                {t('gallery', 'empty_title')}
               </h2>
               <p className="text-gray-300 mb-6">
-                Aún no has generado ninguna imagen viral. ¡Empieza ahora!
+                {t('gallery', 'empty_desc')}
               </p>
               <a
                 href="/generate"
                 className="inline-flex items-center px-6 py-3 bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 text-white font-semibold rounded-xl transition-all duration-300 transform hover:scale-105"
               >
-                Generar mi primera imagen
+                {t('gallery', 'generate_first')}
               </a>
             </div>
           </motion.div>
@@ -191,7 +193,7 @@ const Gallery: React.FC = () => {
                       className="flex-1 bg-gradient-to-r from-green-600 to-blue-600 hover:from-green-700 hover:to-blue-700 disabled:from-gray-600 disabled:to-gray-600 text-white font-semibold py-2 px-4 rounded-lg transition-all duration-300 disabled:cursor-not-allowed flex items-center justify-center space-x-2"
                     >
                       <Download className="h-4 w-4" />
-                      <span>Descargar</span>
+                      <span>{t('gallery', 'download')}</span>
                     </button>
                     <button
                       onClick={() => handleDelete(image.id)}

--- a/src/pages/Generate.tsx
+++ b/src/pages/Generate.tsx
@@ -6,6 +6,7 @@ import { Upload, Sparkles, Download, ArrowLeft, Loader2 } from 'lucide-react';
 import ReactCompareImage from 'react-compare-image';
 import { supabase } from '../lib/supabase';
 import { useAuthContext } from '../components/AuthProvider';
+import { useLanguage } from '../components/LanguageProvider';
 import toast from 'react-hot-toast';
 
 interface ViralTemplate {
@@ -21,6 +22,7 @@ const Generate: React.FC = () => {
   const [searchParams] = useSearchParams();
   const templateId = searchParams.get('template');
   const { profile } = useAuthContext();
+  const { t } = useLanguage();
   
   const [selectedTemplate, setSelectedTemplate] = useState<ViralTemplate | null>(null);
   const [templates, setTemplates] = useState<ViralTemplate[]>([]);
@@ -55,7 +57,7 @@ const Generate: React.FC = () => {
       setTemplates(data || []);
     } catch (error) {
       console.error('Error fetching templates:', error);
-      toast.error('Error al cargar las plantillas');
+      toast.error(t('generate', 'error_loading_templates'));
     }
   };
 
@@ -83,7 +85,7 @@ const Generate: React.FC = () => {
     if (!selectedTemplate || !uploadedImage || !profile) return;
 
     if (profile.credits < 1) {
-      toast.error('No tienes suficientes créditos para generar una imagen');
+      toast.error(t('generate', 'insufficient_credits'));
       return;
     }
 
@@ -119,10 +121,10 @@ const Generate: React.FC = () => {
         .update({ credits: profile.credits - 1 })
         .eq('id', profile.id);
 
-      toast.success('¡Imagen generada exitosamente!');
+      toast.success(t('generate', 'success'));
     } catch (error) {
       console.error('Error generating image:', error);
-      toast.error('Error al generar la imagen');
+      toast.error(t('generate', 'error_generating'));
       setStep('upload');
     } finally {
       setIsGenerating(false);
@@ -155,10 +157,10 @@ const Generate: React.FC = () => {
           className="text-center mb-12"
         >
           <h1 className="text-4xl font-bold text-white mb-4">
-            Generar Imagen Viral
+            {t('generate', 'title')}
           </h1>
           <p className="text-xl text-gray-300">
-            Sigue estos pasos para crear tu imagen viral
+            {t('generate', 'subtitle')}
           </p>
         </motion.div>
 
@@ -166,10 +168,10 @@ const Generate: React.FC = () => {
         <div className="flex justify-center mb-12">
           <div className="flex items-center space-x-4">
             {[
-              { key: 'template', label: '1. Plantilla', icon: Sparkles },
-              { key: 'upload', label: '2. Subir Imagen', icon: Upload },
-              { key: 'generate', label: '3. Generar', icon: Loader2 },
-              { key: 'result', label: '4. Resultado', icon: Download },
+              { key: 'template', label: t('generate', 'step_template'), icon: Sparkles },
+              { key: 'upload', label: t('generate', 'step_upload'), icon: Upload },
+              { key: 'generate', label: t('generate', 'step_generate'), icon: Loader2 },
+              { key: 'result', label: t('generate', 'step_result'), icon: Download },
             ].map((stepItem, index) => {
               const Icon = stepItem.icon;
               const isActive = step === stepItem.key;
@@ -210,7 +212,7 @@ const Generate: React.FC = () => {
             transition={{ duration: 0.5 }}
             className="space-y-6"
           >
-            <h2 className="text-2xl font-bold text-white mb-6">Selecciona una plantilla</h2>
+            <h2 className="text-2xl font-bold text-white mb-6">{t('generate', 'select_template')}</h2>
             <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
               {templates.map((template) => (
                 <motion.div
@@ -268,18 +270,18 @@ const Generate: React.FC = () => {
             className="space-y-6"
           >
             <div className="flex items-center justify-between">
-              <h2 className="text-2xl font-bold text-white">Sube tu imagen</h2>
+              <h2 className="text-2xl font-bold text-white">{t('generate', 'upload_image')}</h2>
               <button
                 onClick={() => setStep('template')}
                 className="flex items-center space-x-2 text-gray-400 hover:text-white transition-colors"
               >
                 <ArrowLeft className="h-4 w-4" />
-                <span>Cambiar plantilla</span>
+                <span>{t('generate', 'change_template')}</span>
               </button>
             </div>
 
             <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-6 border border-white/20">
-              <h3 className="text-lg font-bold text-white mb-4">Plantilla seleccionada: {selectedTemplate.title}</h3>
+              <h3 className="text-lg font-bold text-white mb-4">{t('generate', 'selected_template')}: {selectedTemplate.title}</h3>
               <div className="aspect-video bg-gradient-to-br from-purple-600 to-pink-600 rounded-xl overflow-hidden mb-4">
                 {selectedTemplate.reference_image_url ? (
                   <img
@@ -307,17 +309,17 @@ const Generate: React.FC = () => {
               <div className="text-center">
                 <Upload className="h-12 w-12 text-gray-400 mx-auto mb-4" />
                 <p className="text-lg text-white mb-2">
-                  {isDragActive ? 'Suelta la imagen aquí' : 'Arrastra una imagen o haz clic para seleccionar'}
+                  {isDragActive ? t('generate', 'drag_here') : t('generate', 'drag_prompt')}
                 </p>
                 <p className="text-gray-400">
-                  Formatos soportados: JPG, PNG, WEBP
+                  {t('generate', 'formats')}
                 </p>
               </div>
             </div>
 
             {uploadedImage && (
               <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-6 border border-white/20">
-                <h3 className="text-lg font-bold text-white mb-4">Imagen subida</h3>
+                <h3 className="text-lg font-bold text-white mb-4">{t('generate', 'image_uploaded')}</h3>
                 <div className="aspect-video bg-gray-800 rounded-xl overflow-hidden mb-4">
                   <img
                     src={uploadedImage}
@@ -330,7 +332,7 @@ const Generate: React.FC = () => {
                   disabled={!profile || profile.credits < 1}
                   className="w-full bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 disabled:from-gray-600 disabled:to-gray-600 text-white font-semibold py-4 px-6 rounded-xl transition-all duration-300 transform hover:scale-105 disabled:transform-none disabled:cursor-not-allowed"
                 >
-                  {profile && profile.credits < 1 ? 'Sin créditos suficientes' : 'Generar Imagen Viral (1 crédito)'}
+                  {profile && profile.credits < 1 ? t('generate', 'no_credits') : t('generate', 'generate_button')}
                 </button>
               </div>
             )}
@@ -347,9 +349,9 @@ const Generate: React.FC = () => {
           >
             <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-12 border border-white/20">
               <div className="animate-spin rounded-full h-16 w-16 border-b-2 border-purple-400 mx-auto mb-6"></div>
-              <h2 className="text-2xl font-bold text-white mb-4">Generando tu imagen viral...</h2>
+              <h2 className="text-2xl font-bold text-white mb-4">{t('generate', 'generating')}</h2>
               <p className="text-gray-300">
-                Estamos aplicando la magia de la IA. Esto tomará unos segundos.
+                {t('generate', 'generating_desc')}
               </p>
             </div>
           </motion.div>
@@ -364,9 +366,9 @@ const Generate: React.FC = () => {
             className="space-y-6"
           >
             <div className="text-center">
-              <h2 className="text-2xl font-bold text-white mb-4">¡Tu imagen viral está lista!</h2>
+              <h2 className="text-2xl font-bold text-white mb-4">{t('generate', 'result_title')}</h2>
               <p className="text-gray-300">
-                Desliza para ver la comparación antes/después
+                {t('generate', 'result_desc')}
               </p>
             </div>
 
@@ -391,13 +393,13 @@ const Generate: React.FC = () => {
                   className="flex-1 bg-gradient-to-r from-green-600 to-blue-600 hover:from-green-700 hover:to-blue-700 text-white font-semibold py-4 px-6 rounded-xl transition-all duration-300 transform hover:scale-105 flex items-center justify-center space-x-2"
                 >
                   <Download className="h-5 w-5" />
-                  <span>Descargar Imagen</span>
+                  <span>{t('generate', 'download')}</span>
                 </button>
                 <button
                   onClick={resetGeneration}
                   className="flex-1 bg-white/10 hover:bg-white/20 text-white font-semibold py-4 px-6 rounded-xl transition-all duration-300 backdrop-blur-sm"
                 >
-                  Generar Otra
+                  {t('generate', 'generate_another')}
                 </button>
               </div>
             </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -4,6 +4,7 @@ import { motion } from 'framer-motion';
 import { Sparkles, TrendingUp, Users, Zap } from 'lucide-react';
 import { supabase } from '../lib/supabase';
 import { useAuthContext } from '../components/AuthProvider';
+import { useLanguage } from '../components/LanguageProvider';
 
 interface ViralTemplate {
   id: string;
@@ -18,6 +19,7 @@ const Home: React.FC = () => {
   const [templates, setTemplates] = useState<ViralTemplate[]>([]);
   const [loading, setLoading] = useState(true);
   const { isAuthenticated } = useAuthContext();
+  const { t } = useLanguage();
 
   useEffect(() => {
     fetchTemplates();
@@ -107,14 +109,13 @@ const Home: React.FC = () => {
           >
             <h1 className="text-5xl md:text-7xl font-bold mb-6">
               <span className="bg-gradient-to-r from-purple-400 via-pink-400 to-blue-400 bg-clip-text text-transparent">
-                Convierte tu imagen
+                {t('home', 'tagline1')}
               </span>
               <br />
-              <span className="text-white">en una tendencia</span>
+              <span className="text-white">{t('home', 'tagline2')}</span>
             </h1>
             <p className="text-xl text-gray-300 mb-8 max-w-3xl mx-auto">
-              Transforma tus fotos en imágenes virales usando IA generativa. 
-              Sin necesidad de saber ingeniería de prompts, solo sube tu imagen y elige una plantilla.
+              {t('home', 'hero_desc')}
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               {isAuthenticated ? (
@@ -122,21 +123,21 @@ const Home: React.FC = () => {
                   to="/generate"
                   className="px-8 py-4 bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 text-white font-semibold rounded-xl transition-all duration-300 transform hover:scale-105"
                 >
-                  Generar Ahora
+                  {t('home', 'generate_now')}
                 </Link>
               ) : (
                 <Link
                   to="/register"
                   className="px-8 py-4 bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 text-white font-semibold rounded-xl transition-all duration-300 transform hover:scale-105"
                 >
-                  Comenzar Gratis
+                  {t('home', 'start_free')}
                 </Link>
               )}
               <Link
                 to="#templates"
                 className="px-8 py-4 bg-white/10 hover:bg-white/20 text-white font-semibold rounded-xl transition-all duration-300 backdrop-blur-sm"
               >
-                Ver Plantillas
+                {t('home', 'view_templates')}
               </Link>
             </div>
           </motion.div>
@@ -153,10 +154,10 @@ const Home: React.FC = () => {
             className="text-center mb-16"
           >
             <h2 className="text-4xl font-bold text-white mb-4">
-              ¿Por qué elegir ViralGenAI?
+              {t('home', 'why_choose')}
             </h2>
             <p className="text-xl text-gray-300 max-w-2xl mx-auto">
-              Creamos la mejor experiencia para generar contenido viral
+              {t('home', 'best_exp')}
             </p>
           </motion.div>
 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -4,6 +4,7 @@ import { motion } from 'framer-motion';
 import { Eye, EyeOff, Sparkles } from 'lucide-react';
 import { useAuthContext } from '../components/AuthProvider';
 import toast from 'react-hot-toast';
+import { useLanguage } from '../components/LanguageProvider';
 
 const Login: React.FC = () => {
   const [email, setEmail] = useState('');
@@ -12,6 +13,7 @@ const Login: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const { signIn } = useAuthContext();
   const navigate = useNavigate();
+  const { t } = useLanguage();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -44,15 +46,15 @@ const Login: React.FC = () => {
             </span>
           </div>
           <h2 className="text-3xl font-bold text-white">
-            Inicia sesión en tu cuenta
+            {t('login', 'title')}
           </h2>
           <p className="mt-2 text-gray-400">
-            ¿No tienes una cuenta?{' '}
+            {t('login', 'no_account')} {' '}
             <Link
               to="/register"
               className="text-purple-400 hover:text-purple-300 transition-colors"
             >
-              Regístrate aquí
+              {t('login', 'register_here')}
             </Link>
           </p>
         </div>
@@ -61,7 +63,7 @@ const Login: React.FC = () => {
           <form onSubmit={handleSubmit} className="space-y-6">
             <div>
               <label htmlFor="email" className="block text-sm font-medium text-white mb-2">
-                Correo electrónico
+                {t('login', 'email')}
               </label>
               <input
                 id="email"
@@ -76,7 +78,7 @@ const Login: React.FC = () => {
 
             <div>
               <label htmlFor="password" className="block text-sm font-medium text-white mb-2">
-                Contraseña
+                {t('login', 'password')}
               </label>
               <div className="relative">
                 <input
@@ -103,18 +105,18 @@ const Login: React.FC = () => {
               disabled={loading}
               className="w-full bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 disabled:from-gray-600 disabled:to-gray-600 text-white font-semibold py-4 px-6 rounded-xl transition-all duration-300 transform hover:scale-105 disabled:transform-none disabled:cursor-not-allowed"
             >
-              {loading ? 'Iniciando sesión...' : 'Iniciar sesión'}
+              {loading ? t('login', 'submitting') : t('login', 'submit')}
             </button>
           </form>
 
           <div className="mt-6 text-center">
             <p className="text-sm text-gray-400">
-              ¿Olvidaste tu contraseña?{' '}
+              {t('login', 'forgot')} {' '}
               <Link
                 to="/reset-password"
                 className="text-purple-400 hover:text-purple-300 transition-colors"
               >
-                Recuperar contraseña
+                {t('login', 'recover')}
               </Link>
             </p>
           </div>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -21,10 +21,10 @@ const Login: React.FC = () => {
 
     try {
       await signIn(email, password);
-      toast.success('¡Bienvenido de vuelta!');
+      toast.success(t('login', 'success'));
       navigate('/');
     } catch (error: any) {
-      toast.error(error.message || 'Error al iniciar sesión');
+      toast.error(error.message || t('login', 'error'));
     } finally {
       setLoading(false);
     }

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -4,6 +4,7 @@ import { motion } from 'framer-motion';
 import { Eye, EyeOff, Sparkles } from 'lucide-react';
 import { useAuthContext } from '../components/AuthProvider';
 import toast from 'react-hot-toast';
+import { useLanguage } from '../components/LanguageProvider';
 
 const Register: React.FC = () => {
   const [email, setEmail] = useState('');
@@ -13,6 +14,7 @@ const Register: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const { signUp } = useAuthContext();
   const navigate = useNavigate();
+  const { t } = useLanguage();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -45,15 +47,15 @@ const Register: React.FC = () => {
             </span>
           </div>
           <h2 className="text-3xl font-bold text-white">
-            Crea tu cuenta
+            {t('register', 'title')}
           </h2>
           <p className="mt-2 text-gray-400">
-            ¿Ya tienes una cuenta?{' '}
+            {t('register', 'have_account')} {' '}
             <Link
               to="/login"
               className="text-purple-400 hover:text-purple-300 transition-colors"
             >
-              Inicia sesión aquí
+              {t('register', 'login_here')}
             </Link>
           </p>
         </div>
@@ -62,7 +64,7 @@ const Register: React.FC = () => {
           <form onSubmit={handleSubmit} className="space-y-6">
             <div>
               <label htmlFor="fullName" className="block text-sm font-medium text-white mb-2">
-                Nombre completo
+                {t('register', 'full_name')}
               </label>
               <input
                 id="fullName"
@@ -77,7 +79,7 @@ const Register: React.FC = () => {
 
             <div>
               <label htmlFor="email" className="block text-sm font-medium text-white mb-2">
-                Correo electrónico
+                {t('register', 'email')}
               </label>
               <input
                 id="email"
@@ -92,7 +94,7 @@ const Register: React.FC = () => {
 
             <div>
               <label htmlFor="password" className="block text-sm font-medium text-white mb-2">
-                Contraseña
+                {t('register', 'password')}
               </label>
               <div className="relative">
                 <input
@@ -103,7 +105,7 @@ const Register: React.FC = () => {
                   required
                   minLength={6}
                   className="w-full px-4 py-3 bg-white/10 border border-white/20 rounded-xl text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-all duration-200 pr-12"
-                  placeholder="Mínimo 6 caracteres"
+                  placeholder={t('register', 'placeholder_password')}
                 />
                 <button
                   type="button"
@@ -120,7 +122,7 @@ const Register: React.FC = () => {
               disabled={loading}
               className="w-full bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 disabled:from-gray-600 disabled:to-gray-600 text-white font-semibold py-4 px-6 rounded-xl transition-all duration-300 transform hover:scale-105 disabled:transform-none disabled:cursor-not-allowed"
             >
-              {loading ? 'Creando cuenta...' : 'Crear cuenta'}
+              {loading ? t('register', 'submitting') : t('register', 'submit')}
             </button>
           </form>
 

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -22,10 +22,10 @@ const Register: React.FC = () => {
 
     try {
       await signUp(email, password, fullName);
-      toast.success('¡Cuenta creada exitosamente! Ya puedes generar imágenes.');
+      toast.success(t('register', 'success'));
       navigate('/');
     } catch (error: any) {
-      toast.error(error.message || 'Error al crear la cuenta');
+      toast.error(error.message || t('register', 'error'));
     } finally {
       setLoading(false);
     }
@@ -128,26 +128,26 @@ const Register: React.FC = () => {
 
           <div className="mt-6 text-center">
             <p className="text-sm text-gray-400">
-              Al registrarte, aceptas nuestros{' '}
+              {t('register', 'terms_prefix')}{' '}
               <Link
                 to="/terms"
                 className="text-purple-400 hover:text-purple-300 transition-colors"
               >
-                términos de servicio
+                {t('register', 'terms')}
               </Link>
               {' '}y{' '}
               <Link
                 to="/privacy"
                 className="text-purple-400 hover:text-purple-300 transition-colors"
               >
-                política de privacidad
+                {t('register', 'privacy')}
               </Link>
             </p>
           </div>
 
           <div className="mt-6 p-4 bg-green-600/20 border border-green-600/30 rounded-xl">
             <p className="text-sm text-green-300 text-center">
-              🎉 ¡Obtén 3 créditos gratis para empezar a generar imágenes virales!
+              {t('register', 'free_credits')}
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- implement `LanguageProvider` with language toggle
- create translation tables for Spanish and English
- wrap app with provider and translate navigation, home, login, register, and gallery pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68729a02a2148332a69a1b9f41ed3c41