### PR TITLE
Implement image generation via OpenAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-magicphoto
+# MagicPhoto
+
+This project allows you to upload a photo and transform it with generative AI templates.
+
+## Environment variables
+
+The application expects the following variables to be defined at build time:
+
+- `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` for Supabase access.
+- `VITE_OPENAI_KEY` for the OpenAI image API.
+- `VITE_IMAGE_API_PROVIDER` (optional) to choose the image generation provider. Currently only `openai` is implemented and used by default.
+

--- a/src/lib/imageApi.ts
+++ b/src/lib/imageApi.ts
@@ -1,0 +1,48 @@
+export interface ImageConversionService {
+  convertImage(options: { image: File; prompt: string }): Promise<string>;
+}
+
+export class OpenAIImageConversionService implements ImageConversionService {
+  private apiKey: string;
+
+  constructor(apiKey: string) {
+    this.apiKey = apiKey;
+  }
+
+  async convertImage({ image, prompt }: { image: File; prompt: string }): Promise<string> {
+    const formData = new FormData();
+    formData.append('image', image);
+    formData.append('prompt', prompt);
+    formData.append('n', '1');
+    formData.append('size', '1024x1024');
+
+    const response = await fetch('https://api.openai.com/v1/images/edits', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: formData,
+    });
+
+    if (!response.ok) {
+      throw new Error('OpenAI image generation failed');
+    }
+
+    const data = await response.json();
+    return data.data?.[0]?.url as string;
+  }
+}
+
+export function createImageConversionService(): ImageConversionService {
+  const provider = import.meta.env.VITE_IMAGE_API_PROVIDER || 'openai';
+
+  if (provider === 'openai') {
+    const key = import.meta.env.VITE_OPENAI_KEY;
+    if (!key) {
+      throw new Error('Missing OpenAI API key');
+    }
+    return new OpenAIImageConversionService(key);
+  }
+
+  throw new Error(`Unsupported provider: ${provider}`);
+}


### PR DESCRIPTION
## Summary
- implement a generic image conversion service with an OpenAI implementation
- hook the new service into the Generate page
- document required environment variables

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873c2424e70833283dcff1d79778729