### PR TITLE
Move OpenAI calls to backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ This project allows you to upload a photo and transform it with generative AI te
 The application expects the following variables to be defined at build time:
 
 - `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` for Supabase access.
-- `VITE_OPENAI_KEY` for the OpenAI image API.
+- `VITE_BACKEND_URL` pointing to the backend server.
 - `VITE_IMAGE_API_PROVIDER` (optional) to choose the image generation provider. Currently only `openai` is implemented and used by default.
+
+The backend server requires an additional environment variable:
+
+- `OPENAI_API_KEY` used to call the OpenAI image API.
+
+Start the backend using:
+
+```bash
+npm run server
+```
 

--- a/package.json
+++ b/package.json
@@ -7,13 +7,16 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "node server/server.js"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.50.5",
     "clsx": "^2.1.1",
+    "express": "^4.19.2",
     "framer-motion": "^12.23.3",
     "lucide-react": "^0.525.0",
+    "multer": "^1.4.5",
     "react": "^18.3.1",
     "react-compare-image": "^3.5.6",
     "react-dom": "^18.3.1",

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,49 @@
+import express from 'express';
+import multer from 'multer';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const app = express();
+const upload = multer();
+
+app.post('/api/openai/edit', upload.single('image'), async (req, res) => {
+  const prompt = req.body.prompt;
+  const file = req.file;
+
+  if (!prompt || !file) {
+    return res.status(400).json({ error: 'Missing prompt or image' });
+  }
+
+  try {
+    const formData = new FormData();
+    formData.append('image', new Blob([file.buffer], { type: file.mimetype }), file.originalname);
+    formData.append('prompt', prompt);
+    formData.append('n', '1');
+    formData.append('size', '1024x1024');
+
+    const response = await fetch('https://api.openai.com/v1/images/edits', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      },
+      body: formData,
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      return res.status(500).json({ error: 'OpenAI request failed', details: text });
+    }
+
+    const data = await response.json();
+    res.json({ url: data.data?.[0]?.url });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+const port = process.env.PORT || 3001;
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- implement a simple Express backend with an endpoint that forwards image edit requests to OpenAI
- use new `BackendImageConversionService` on the frontend to call the backend
- document new environment variables and backend usage
- add server script and dependencies

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68740dda45c483328cb46cd76bfe7ff4