### PR TITLE
Fix react object error on gallery page

### DIFF
--- a/src/pages/Gallery.tsx
+++ b/src/pages/Gallery.tsx
@@ -1,7 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { Download, Trash2, Calendar, Sparkles } from 'lucide-react';
-import ReactCompareImage from 'react-compare-image';
+import ReactCompareImageModule from 'react-compare-image';
+const ReactCompareImage =
+  // Some bundlers require .default when using CommonJS modules
+  (ReactCompareImageModule as any).default || ReactCompareImageModule;
 import { supabase } from '../lib/supabase';
 import { useAuthContext } from '../components/AuthProvider';
 import toast from 'react-hot-toast';


### PR DESCRIPTION
## Summary
- handle CJS/ESM default export for `react-compare-image`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6874cc2360cc8332ae0344b65fd97dd6