### PR TITLE
Fix templates button

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -133,12 +133,12 @@ const Home: React.FC = () => {
                   {t('home', 'start_free')}
                 </Link>
               )}
-              <Link
-                to="#templates"
+              <a
+                href="#templates"
                 className="px-8 py-4 bg-white/10 hover:bg-white/20 text-white font-semibold rounded-xl transition-all duration-300 backdrop-blur-sm"
               >
                 {t('home', 'view_templates')}
-              </Link>
+              </a>
             </div>
           </motion.div>
         </div>


### PR DESCRIPTION
## Summary
- fix the "Ver plantillas" button so it uses an anchor link

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68750386157c83329a51b69932fba55a