### PR TITLE
Fix gallery ReactCompareImage import

### DIFF
--- a/src/pages/Gallery.tsx
+++ b/src/pages/Gallery.tsx
@@ -1,10 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { Download, Trash2, Calendar, Sparkles } from 'lucide-react';
-import ReactCompareImageModule from 'react-compare-image';
-const ReactCompareImage =
-  // Some bundlers require .default when using CommonJS modules
-  (ReactCompareImageModule as any).default || ReactCompareImageModule;
+import ReactCompareImage from 'react-compare-image';
 import { supabase } from '../lib/supabase';
 import { useAuthContext } from '../components/AuthProvider';
 import toast from 'react-hot-toast';


### PR DESCRIPTION
## Summary
- correct ReactCompareImage import in `Gallery.tsx`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68750b712ed48332bc1106dd0e2f2ca3