### PR TITLE
Fix gallery images and add sharing

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -65,6 +65,9 @@ export const translations = {
       empty_desc: 'Aún no has generado ninguna imagen viral. ¡Empieza ahora!',
       generate_first: 'Generar mi primera imagen',
       download: 'Descargar',
+      share_facebook: 'Compartir en Facebook',
+      share_instagram: 'Compartir en Instagram',
+      share_x: 'Compartir en X',
       delete_confirm: '¿Estás seguro de que quieres eliminar esta imagen?'
     },
     generate: {
@@ -160,6 +163,9 @@ export const translations = {
       empty_desc: "You haven't generated any viral images yet. Start now!",
       generate_first: 'Generate my first image',
       download: 'Download',
+      share_facebook: 'Share on Facebook',
+      share_instagram: 'Share on Instagram',
+      share_x: 'Share on X',
       delete_confirm: 'Are you sure you want to delete this image?'
     },
     generate: {

--- a/src/pages/Gallery.tsx
+++ b/src/pages/Gallery.tsx
@@ -1,10 +1,14 @@
 import React, { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
-import { Download, Trash2, Calendar, Sparkles } from 'lucide-react';
-import ReactCompareImageModule from 'react-compare-image';
-const ReactCompareImage =
-  // Some bundlers require .default when using CommonJS modules
-  (ReactCompareImageModule as any).default || ReactCompareImageModule;
+import {
+  Download,
+  Trash2,
+  Calendar,
+  Sparkles,
+  Facebook,
+  Instagram,
+  Twitter
+} from 'lucide-react';
 import { supabase } from '../lib/supabase';
 import { useAuthContext } from '../components/AuthProvider';
 import toast from 'react-hot-toast';
@@ -88,6 +92,23 @@ const Gallery: React.FC = () => {
     }
   };
 
+  const handleShare = (platform: 'facebook' | 'instagram' | 'x', imageUrl: string) => {
+    const url = encodeURIComponent(imageUrl);
+    let shareUrl = '';
+    switch (platform) {
+      case 'facebook':
+        shareUrl = `https://www.facebook.com/sharer/sharer.php?u=${url}`;
+        break;
+      case 'instagram':
+        shareUrl = `https://www.instagram.com/sharing?url=${url}`;
+        break;
+      case 'x':
+        shareUrl = `https://twitter.com/intent/tweet?url=${url}`;
+        break;
+    }
+    window.open(shareUrl, '_blank');
+  };
+
   if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
@@ -149,25 +170,17 @@ const Gallery: React.FC = () => {
                 transition={{ duration: 0.5, delay: index * 0.1 }}
                 className="bg-white/10 backdrop-blur-sm rounded-2xl overflow-hidden border border-white/20 hover:border-white/40 transition-all duration-300"
               >
-                <div className="aspect-video overflow-hidden">
+                <div className="aspect-video overflow-hidden bg-gray-800 flex items-center justify-center">
                   {image.status === 'completed' && image.generated_image_url ? (
-                    <ReactCompareImage
-                      leftImage={image.original_image_url}
-                      rightImage={image.generated_image_url}
-                      sliderLineColor="#8B5CF6"
-                      sliderLineWidth={2}
-                      handle={
-                        <div className="w-6 h-6 bg-purple-600 rounded-full border-2 border-white flex items-center justify-center">
-                          <div className="w-1.5 h-1.5 bg-white rounded-full"></div>
-                        </div>
-                      }
+                    <img
+                      src={image.generated_image_url}
+                      alt={image.viral_templates?.title || 'Imagen generada'}
+                      className="w-full h-full object-cover"
                     />
                   ) : (
-                    <div className="w-full h-full flex items-center justify-center bg-gray-800">
-                      <div className="text-center">
-                        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-purple-400 mx-auto mb-2"></div>
-                        <p className="text-gray-400 text-sm">Generando...</p>
-                      </div>
+                    <div className="text-center">
+                      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-purple-400 mx-auto mb-2"></div>
+                      <p className="text-gray-400 text-sm">Generando...</p>
                     </div>
                   )}
                 </div>
@@ -189,7 +202,7 @@ const Gallery: React.FC = () => {
                     {image.viral_templates?.description || 'Descripción no disponible'}
                   </p>
 
-                  <div className="flex space-x-2">
+                  <div className="flex flex-wrap gap-2">
                     <button
                       onClick={() => handleDownload(image.generated_image_url, image.viral_templates?.title || 'imagen')}
                       disabled={image.status !== 'completed'}
@@ -197,6 +210,27 @@ const Gallery: React.FC = () => {
                     >
                       <Download className="h-4 w-4" />
                       <span>{t('gallery', 'download')}</span>
+                    </button>
+                    <button
+                      onClick={() => handleShare('facebook', image.generated_image_url)}
+                      className="bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded-lg transition-all duration-300 flex items-center justify-center"
+                      title={t('gallery', 'share_facebook')}
+                    >
+                      <Facebook className="h-4 w-4" />
+                    </button>
+                    <button
+                      onClick={() => handleShare('instagram', image.generated_image_url)}
+                      className="bg-pink-600 hover:bg-pink-700 text-white font-semibold py-2 px-4 rounded-lg transition-all duration-300 flex items-center justify-center"
+                      title={t('gallery', 'share_instagram')}
+                    >
+                      <Instagram className="h-4 w-4" />
+                    </button>
+                    <button
+                      onClick={() => handleShare('x', image.generated_image_url)}
+                      className="bg-black hover:bg-gray-800 text-white font-semibold py-2 px-4 rounded-lg transition-all duration-300 flex items-center justify-center"
+                      title={t('gallery', 'share_x')}
+                    >
+                      <Twitter className="h-4 w-4" />
                     </button>
                     <button
                       onClick={() => handleDelete(image.id)}


### PR DESCRIPTION
## Summary
- drop before/after comparison in `Gallery`
- add social share buttons for Facebook, Instagram and X
- update translations with share messages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68750b712ed48332bc1106dd0e2f2ca3