### PR TITLE
Fix backend URL usage for image API

### DIFF
--- a/src/lib/imageApi.ts
+++ b/src/lib/imageApi.ts
@@ -6,7 +6,8 @@ export class BackendImageConversionService implements ImageConversionService {
   private baseUrl: string;
 
   constructor(baseUrl: string) {
-    this.baseUrl = import.meta.env.VITE_IMAGE_API_PROVIDER;   // baseUrl.replace(/\/$/, '');
+    // Normalize the base URL and store it for later requests
+    this.baseUrl = baseUrl.replace(/\/$/, '');
   }
 
   async convertImage({ image, prompt }: { image: File; prompt: string }): Promise<string> {
@@ -14,7 +15,7 @@ export class BackendImageConversionService implements ImageConversionService {
     formData.append('image', image);
     formData.append('prompt', prompt);
 
-    const response = await fetch(`${this.baseUrl}`, {
+    const response = await fetch(`${this.baseUrl}/api/openai/edit`, {
       method: 'POST',
       body: formData,
     });


### PR DESCRIPTION
## Summary
- fix image API client to respect backend base URL

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68754da999e883328458794b1ff639c5