### PR TITLE
Add simple CORS handling

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -7,6 +7,16 @@ dotenv.config();
 const app = express();
 const upload = multer();
 
+app.use((req, res, next) => {
+  res.header('Access-Control-Allow-Origin', '*');
+  res.header('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+  res.header('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+  if (req.method === 'OPTIONS') {
+    return res.sendStatus(204);
+  }
+  next();
+});
+
 app.post('/api/openai/edit', upload.single('image'), async (req, res) => {
   const prompt = req.body.prompt;
   const file = req.file;

--- a/src/lib/imageApi.ts
+++ b/src/lib/imageApi.ts
@@ -33,9 +33,15 @@ export function createImageConversionService(): ImageConversionService {
   const provider = import.meta.env.VITE_IMAGE_API_PROVIDER || 'openai';
 
   if (provider === 'openai') {
-    // Base URL for the backend API. Defaults to the current origin when the
-    // environment variable is not defined.
-    const url = import.meta.env.VITE_BACKEND_URL || window.location.origin;
+    // Base URL for the backend API. If not provided, fall back to the local
+    // development server when running on the Vite dev port (5173). This avoids
+    // 404 errors when the frontend and backend run on different ports.
+    const defaultUrl =
+      window.location.port === '5173'
+        ? `${window.location.protocol}//${window.location.hostname}:3001`
+        : window.location.origin;
+
+    const url = import.meta.env.VITE_BACKEND_URL || defaultUrl;
     return new BackendImageConversionService(url);
   }
 


### PR DESCRIPTION
## Summary
- add a middleware in `server/server.js` to set CORS headers

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `node server/server.js` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68755c1c27d0833292f41b6801d370da