### PR TITLE
Fix 404 error when API is called from subpath

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -17,7 +17,11 @@ app.use((req, res, next) => {
   next();
 });
 
-app.post('/api/openai/edit', upload.single('image'), async (req, res) => {
+// Support both /api/openai/edit and /generate/api/openai/edit in case the
+// frontend is hosted under a sub-path (e.g. /generate). This prevents 404
+// errors when the API is called with the sub-path prefix.
+const editPaths = ['/api/openai/edit', '/generate/api/openai/edit'];
+app.post(editPaths, upload.single('image'), async (req, res) => {
   const prompt = req.body.prompt;
   const file = req.file;
 


### PR DESCRIPTION
## Summary
- support `/generate/api/openai/edit` path to avoid 404s when the
  frontend is deployed under `/generate`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6876142632148332b15c18964e92c06c