### PR TITLE
Add Netlify function for OpenAI edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,13 @@ Start the backend using:
 npm run server
 ```
 
+
+## Netlify deployment
+
+When deployed on Netlify, the image generation API is handled by a serverless function defined in `netlify/functions/edit.js`. Redirect rules in `netlify.toml` map both `/api/openai/edit` and `/generate/api/openai/edit` to this function, preventing 404 errors when the site is served from a sub-path.
+
+Local development can still use the Express server with:
+
+```bash
+npm run server
+```

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,12 @@
+[functions]
+  node_bundler = "esbuild"
+
+[[redirects]]
+  from = "/api/openai/edit"
+  to = "/.netlify/functions/edit"
+  status = 200
+
+[[redirects]]
+  from = "/generate/api/openai/edit"
+  to = "/.netlify/functions/edit"
+  status = 200

--- a/netlify/functions/edit.js
+++ b/netlify/functions/edit.js
@@ -1,0 +1,46 @@
+import { Buffer } from 'buffer';
+
+export async function handler(event) {
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, body: 'Method Not Allowed' };
+  }
+
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return { statusCode: 500, body: JSON.stringify({ error: 'Missing OpenAI API key' }) };
+  }
+
+  const contentType = event.headers['content-type'] || event.headers['Content-Type'];
+  const bodyBuffer = event.isBase64Encoded
+    ? Buffer.from(event.body, 'base64')
+    : Buffer.from(event.body || '', 'utf8');
+
+  try {
+    const response = await fetch('https://api.openai.com/v1/images/edits', {
+      method: 'POST',
+      headers: {
+        'Content-Type': contentType,
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: bodyBuffer,
+    });
+
+    const text = await response.text();
+    if (!response.ok) {
+      return {
+        statusCode: 500,
+        body: JSON.stringify({ error: 'OpenAI request failed', details: text }),
+      };
+    }
+
+    const data = JSON.parse(text);
+    return {
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url: data.data?.[0]?.url }),
+    };
+  } catch (err) {
+    console.error(err);
+    return { statusCode: 500, body: JSON.stringify({ error: 'Internal server error' }) };
+  }
+}

--- a/server/server.js
+++ b/server/server.js
@@ -17,7 +17,11 @@ app.use((req, res, next) => {
   next();
 });
 
-app.post('/api/openai/edit', upload.single('image'), async (req, res) => {
+// Support both /api/openai/edit and /generate/api/openai/edit in case the
+// frontend is hosted under a sub-path (e.g. /generate). This prevents 404
+// errors when the API is called with the sub-path prefix.
+const editPaths = ['/api/openai/edit', '/generate/api/openai/edit'];
+app.post(editPaths, upload.single('image'), async (req, res) => {
   const prompt = req.body.prompt;
   const file = req.file;
 


### PR DESCRIPTION
## Summary
- implement `netlify/functions/edit.js` to forward multipart POSTs to OpenAI
- add redirect rules in `netlify.toml` for `/api/openai/edit` and `/generate/api/openai/edit`
- document Netlify usage in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_6876142632148332b15c18964e92c06c