### PR TITLE
Implement vision-based prompt enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This project allows you to upload a photo and transform it with generative AI templates.
 
+Uploaded images are first analyzed with the GPT-4 Vision model to obtain a
+textual description. That description is appended to the selected template's
+prompt before the final image generation request is sent to OpenAI.
+
 ## Environment variables
 
 The application expects the following variables to be defined at build time:
@@ -12,7 +16,9 @@ The application expects the following variables to be defined at build time:
 
 The backend server requires an additional environment variable:
 
-- `OPENAI_API_KEY` used to call the OpenAI image API.
+- `OPENAI_API_KEY` used to call the OpenAI APIs. This key is used both for the
+  image generation request and to generate a description of the uploaded image
+  using the GPT-4 Vision model.
 
 Start the backend using:
 

--- a/netlify/functions/edit.js
+++ b/netlify/functions/edit.js
@@ -1,5 +1,71 @@
 import { Buffer } from 'buffer';
 
+async function describeImage(buffer, contentType, apiKey) {
+  const base64 = buffer.toString('base64');
+  const payload = {
+    model: 'gpt-4-vision-preview',
+    messages: [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Describe the image in detail.' },
+          { type: 'image_url', image_url: { url: `data:${contentType};base64,${base64}` } }
+        ]
+      }
+    ],
+    max_tokens: 200
+  };
+
+  const resp = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`
+    },
+    body: JSON.stringify(payload)
+  });
+
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error('Vision request failed: ' + text);
+  }
+
+  const data = await resp.json();
+  const description = data.choices?.[0]?.message?.content?.trim();
+  return description || '';
+}
+
+function parseMultipart(buffer, boundary) {
+  const boundaryText = `--${boundary}`;
+  const boundaryBuf = Buffer.from(boundaryText);
+  const parts = [];
+  let start = buffer.indexOf(boundaryBuf) + boundaryBuf.length + 2; // skip CRLF
+  while (start < buffer.length) {
+    const end = buffer.indexOf(boundaryBuf, start);
+    if (end === -1) break;
+    parts.push(buffer.slice(start, end - 2)); // trim CRLF
+    start = end + boundaryBuf.length + 2;
+  }
+
+  const fields = {};
+  for (const part of parts) {
+    const headerEnd = part.indexOf('\r\n\r\n');
+    const headerStr = part.slice(0, headerEnd).toString();
+    const body = part.slice(headerEnd + 4);
+    const nameMatch = headerStr.match(/name="([^"]+)"/);
+    const name = nameMatch ? nameMatch[1] : '';
+    const filenameMatch = headerStr.match(/filename="([^"]+)"/);
+    if (filenameMatch) {
+      const ctMatch = headerStr.match(/Content-Type: ([^\r\n]+)/);
+      const contentType = ctMatch ? ctMatch[1] : 'application/octet-stream';
+      fields[name] = { filename: filenameMatch[1], contentType, data: body };
+    } else {
+      fields[name] = body.toString();
+    }
+  }
+  return fields;
+}
+
 export async function handler(event) {
   if (event.httpMethod !== 'POST') {
     return { statusCode: 405, body: 'Method Not Allowed' };
@@ -16,13 +82,34 @@ export async function handler(event) {
     : Buffer.from(event.body || '', 'utf8');
 
   try {
+    const boundaryMatch = contentType.match(/boundary=(.*)$/);
+    if (!boundaryMatch) {
+      throw new Error('Missing multipart boundary');
+    }
+    const boundary = boundaryMatch[1];
+    const fields = parseMultipart(bodyBuffer, boundary);
+
+    const imageField = fields.image;
+    const prompt = fields.prompt;
+    if (!imageField || !prompt) {
+      throw new Error('Missing prompt or image');
+    }
+
+    const description = await describeImage(imageField.data, imageField.contentType, apiKey);
+    const combinedPrompt = `${prompt}\n\n${description}`;
+
+    const formData = new FormData();
+    formData.append('image', new Blob([imageField.data], { type: imageField.contentType }), imageField.filename);
+    formData.append('prompt', combinedPrompt);
+    formData.append('n', '1');
+    formData.append('size', '1024x1024');
+
     const response = await fetch('https://api.openai.com/v1/images/edits', {
       method: 'POST',
       headers: {
-        'Content-Type': contentType,
         Authorization: `Bearer ${apiKey}`,
       },
-      body: bodyBuffer,
+      body: formData,
     });
 
     const text = await response.text();

--- a/server/server.js
+++ b/server/server.js
@@ -7,6 +7,44 @@ dotenv.config();
 const app = express();
 const upload = multer();
 
+async function describeImage(buffer, mimetype) {
+  const base64 = buffer.toString('base64');
+  const payload = {
+    model: 'gpt-4-vision-preview',
+    messages: [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Describe the image in detail.' },
+          {
+            type: 'image_url',
+            image_url: { url: `data:${mimetype};base64,${base64}` },
+          },
+        ],
+      },
+    ],
+    max_tokens: 200,
+  };
+
+  const resp = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`Vision request failed: ${text}`);
+  }
+
+  const data = await resp.json();
+  const description = data.choices?.[0]?.message?.content?.trim();
+  return description || '';
+}
+
 app.use((req, res, next) => {
   res.header('Access-Control-Allow-Origin', '*');
   res.header('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
@@ -30,9 +68,14 @@ app.post(editPaths, upload.single('image'), async (req, res) => {
   }
 
   try {
+    // First generate a description of the uploaded image using GPT-4 Vision
+    const description = await describeImage(file.buffer, file.mimetype);
+
+    const combinedPrompt = `${prompt}\n\n${description}`;
+
     const formData = new FormData();
     formData.append('image', new Blob([file.buffer], { type: file.mimetype }), file.originalname);
-    formData.append('prompt', prompt);
+    formData.append('prompt', combinedPrompt);
     formData.append('n', '1');
     formData.append('size', '1024x1024');
 


### PR DESCRIPTION
## Summary
- generate image descriptions using GPT-4 Vision before calling edits API
- append that description to the provided prompt in both server and Netlify function
- document the new vision workflow and API usage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687682a6861083329f915c10167caa07