### PR TITLE
Fix DALL-E prompt generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 This project allows you to upload a photo and transform it with generative AI templates.
 
+Uploaded images are first analyzed with the GPT-4 Vision model to obtain a
+textual description. That description is appended to the selected template's
+prompt before the final image generation request is sent to the DALL·E 3
+`images/generations` endpoint.
+
 
 ## Environment variables
 

--- a/netlify/functions/edit.js
+++ b/netlify/functions/edit.js
@@ -98,7 +98,20 @@ export async function handler(event) {
     const description = await describeImage(imageField.data, imageField.contentType, apiKey);
     const combinedPrompt = `${prompt}\n\n${description}`;
 
+    const payload = {
+      model: 'dall-e-3',
+      prompt: combinedPrompt,
+      n: 1,
+      size: '1024x1024',
+    };
 
+    const response = await fetch('https://api.openai.com/v1/images/generations', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(payload),
     });
 
     const text = await response.text();

--- a/server/server.js
+++ b/server/server.js
@@ -73,6 +73,12 @@ app.post(editPaths, upload.single('image'), async (req, res) => {
 
     const combinedPrompt = `${prompt}\n\n${description}`;
 
+    const payload = {
+      model: 'dall-e-3',
+      prompt: combinedPrompt,
+      n: 1,
+      size: '1024x1024',
+    };
 
     const response = await fetch('https://api.openai.com/v1/images/generations', {
       method: 'POST',


### PR DESCRIPTION
## Summary
- inject Vision description into final prompt and call DALL-E 3
- document the Vision description step in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6877a1596f188332b45c2b86d0dd1f21